### PR TITLE
Docker version property now deprecated

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   api:


### PR DESCRIPTION
Using it causes: 
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"

thus as it's ignored, we might as well clean it up