### PR TITLE
Fix fetch response in openapi docs

### DIFF
--- a/doc/api-documentation.yml
+++ b/doc/api-documentation.yml
@@ -75,7 +75,9 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/dataObject"
+                type: array
+                items:
+                  "$ref": "#/components/schemas/dataObject"
   "/api/v2/push/{method}":
     put:
       operationId: pushData


### PR DESCRIPTION
The fetch method clearly returns a array, this is now reflected in the documentation.